### PR TITLE
[build] Add support for RHEL/Centos/Fedora

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,9 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DDEBUG -Wall -Werror")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -Wall -Werror -ffast-math -funroll-loops -march=native")
 
+set(Boost_USE_STATIC_LIBS OFF) 
+set(Boost_USE_MULTITHREADED ON)  
+set(Boost_USE_STATIC_RUNTIME OFF) 
 find_package(Boost 1.53.0
     COMPONENTS
     unit_test_framework
@@ -24,6 +27,8 @@ find_package(Boost 1.53.0
 find_package(Log4Cxx REQUIRED)
 find_package(Sqlite3 REQUIRED)
 find_package(APR REQUIRED)
+
+find_package(Threads REQUIRED)
 
 include_directories(${Boost_INCLUDE_DIRS})
 include_directories("${APR_INCLUDE_DIR}")
@@ -43,4 +48,3 @@ add_subdirectory(functests)
 
 enable_testing()
 add_subdirectory(unittests)
-

--- a/README.md
+++ b/README.md
@@ -94,7 +94,22 @@ cd boost_1_54_0
 1. `make -j`
 1. `make`
 
-
+### Centos 6 / RHEL6
+#### Prequisites
+* Same as for RHEL7, but we need to manually install log4cxx, as there isn't a package in the repos:
+```
+wget http://www.pirbot.com/mirrors/apache/logging/log4cxx/0.10.0/apache-log4cxx-0.10.0.tar.gz
+tar -xzvf apache-log4cxx-0.10.0.tar.gz 
+cd apache-log4cxx-0.10.0
+```
+* Add `#include <cstring>` to: `src/main/cpp/inputstreamreader.cpp`, `src/main/cpp/socketoutputstream.cpp` and `src/examples/cpp/console.cpp`
+* Add `#include <cstdio>` to: `src/examples/cpp/console.cpp`
+```
+./configure --prefix=/usr --libdir=/usr/lib64
+make -j4
+sudo make install
+```
+* Go on as for RHEL7
 Questions?
 ----------
 [Google group](https://groups.google.com/forum/#!forum/akumuli)

--- a/README.md
+++ b/README.md
@@ -73,12 +73,12 @@ In case automatic script didn't work:
 ##### Semiautomatic
 * RHEL has an old version of boost that didn't really support coroutines (It's 1.53, which should contain coroutines, but compiling fails). At the time of writing, Akumulid needs boost 1.54 PRECISELY, so uninstall the original and get version 1.54 from the boost website:
 ```
-wget 'wget http://downloads.sourceforge.net/project/boost/boost/1.54.0/boost_1_54_0.tar.gz'
+wget 'http://downloads.sourceforge.net/project/boost/boost/1.54.0/boost_1_54_0.tar.gz'
 tar -xzvf boost_1_54_0.tar.gz
 cd boost_1_54_0
 ./bootstrap.sh --prefix=/usr --libdir=/usr/lib64
-./b2
-#Go get some coffee...
+./b2 -j4 
+#Go get some coffee (-j4: Use four cores)...
 ./b2 install
 #Go get some more coffee...
 ```

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ In case automatic script didn't work:
   
 * APR:
 
-  `sudo apt-get install libapr1-dev libaprutil1-dev
+  `sudo apt-get install libapr1-dev libaprutil1-dev`
 
 * Cmake:
 
@@ -67,6 +67,30 @@ In case automatic script didn't work:
 
 1. `cmake .`
 1. `make -j`
+
+### Centos 7 / RHEL7 / Fedora?
+#### Prerequisites
+##### Semiautomatic
+* RHEL has an old version of boost that didn't really support coroutines (It's 1.53, which should contain coroutines, but compiling fails). At the time of writing, Akumulid needs boost 1.54 PRECISELY, so uninstall the original and get version 1.54 from the boost website:
+  `wget 'wget http://downloads.sourceforge.net/project/boost/boost/1.54.0/boost_1_54_0.tar.gz'`
+  `tar -xzvf boost_1_54_0.tar.gz`
+  `cd boost_1_54_0`
+  `./bootstrap.sh --prefix=/usr --libdir=/usr/lib64`
+  `./b2`
+  #Go get some coffee...
+  `./b2 install`
+  #Go get some more coffee...
+
+* If there are errors `quadmath.h: No such file or directory`, do: yum install libquadmath-devel
+* If there are errors `bzlib.h: No such file or directory`, do: yum install bzip2-devel
+* If there are errors `pyconfig.h: No such file or directory`, do: yum install python-devel
+* Then run `prerequisites.sh` to install the remaining libraries
+
+#### Building
+
+1. `cmake .`
+1. `make -j`
+
 
 Questions?
 ----------

--- a/README.md
+++ b/README.md
@@ -72,24 +72,27 @@ In case automatic script didn't work:
 #### Prerequisites
 ##### Semiautomatic
 * RHEL has an old version of boost that didn't really support coroutines (It's 1.53, which should contain coroutines, but compiling fails). At the time of writing, Akumulid needs boost 1.54 PRECISELY, so uninstall the original and get version 1.54 from the boost website:
-  `wget 'wget http://downloads.sourceforge.net/project/boost/boost/1.54.0/boost_1_54_0.tar.gz'`
-  `tar -xzvf boost_1_54_0.tar.gz`
-  `cd boost_1_54_0`
-  `./bootstrap.sh --prefix=/usr --libdir=/usr/lib64`
-  `./b2`
-  #Go get some coffee...
-  `./b2 install`
-  #Go get some more coffee...
-
-* If there are errors `quadmath.h: No such file or directory`, do: yum install libquadmath-devel
-* If there are errors `bzlib.h: No such file or directory`, do: yum install bzip2-devel
-* If there are errors `pyconfig.h: No such file or directory`, do: yum install python-devel
+```
+wget 'wget http://downloads.sourceforge.net/project/boost/boost/1.54.0/boost_1_54_0.tar.gz'
+tar -xzvf boost_1_54_0.tar.gz
+cd boost_1_54_0
+./bootstrap.sh --prefix=/usr --libdir=/usr/lib64
+./b2
+#Go get some coffee...
+./b2 install
+#Go get some more coffee...
+```
+* We're assuming x86_64, otherwise, adapt libdir accordingly
+* If there are errors `quadmath.h: No such file or directory`, do: `yum install libquadmath-devel`
+* If there are errors `bzlib.h: No such file or directory`, do: `yum install bzip2-devel`
+* If there are errors `pyconfig.h: No such file or directory`, do: `yum install python-devel`
 * Then run `prerequisites.sh` to install the remaining libraries
 
 #### Building
 
 1. `cmake .`
 1. `make -j`
+1. `make`
 
 
 Questions?

--- a/libakumuli/metadatastorage.cpp
+++ b/libakumuli/metadatastorage.cpp
@@ -71,7 +71,7 @@ MetadataStorage::MetadataStorage(const char* db, aku_logger_cb_t logger)
     status = apr_dbd_get_driver(pool, "sqlite3", &driver_);
     if (status != APR_SUCCESS) {
         (*logger_)(AKU_LOG_ERROR, "Can't load driver, maybe libaprutil1-dbd-sqlite3 isn't installed");
-        throw std::runtime_error("Can't load sqlite3 dirver");
+        throw std::runtime_error("Can't load sqlite3 driver");
     }
 
     apr_dbd_t *handle = nullptr;

--- a/prerequisites.sh
+++ b/prerequisites.sh
@@ -20,7 +20,7 @@ if [ "x$pkgman" = "xyum" ]; then
 	#sudo yum install boost boost-devel boost-thread
 	sudo yum install log4cxx log4cxx-devel
 	sudo yum install sqlite sqlite-devel
-	sudo yum install apr-util-devel
+	sudo yum install apr-util-devel apr-util-sqlite
 	sudo yum install libmicrohttpd-devel
 	sudo yum install jemalloc-devel
 	sudo yum install python-devel

--- a/prerequisites.sh
+++ b/prerequisites.sh
@@ -1,20 +1,44 @@
 #!/bin/sh
 
-echo 'The script will install packages using apt-get.' \
-     'It can ask for your sudo password.'
-     
-echo 'Trying to install boost libraries'
-sudo apt-get install -y libboost-dev libboost-system-dev libboost-thread-dev \
-     libboost-filesystem-dev libboost-test-dev 
-sudo apt-get install -y libboost-coroutine-dev \
-     libboost-context-dev \
-     libboost-program-options-dev libboost-regex-dev
-     
-echo 'Trying to install other libraries'
-sudo apt-get install -y libapr1-dev libaprutil1-dev libaprutil1-dbd-sqlite3 libmicrohttpd-dev
-sudo apt-get install -y liblog4cxx10-dev liblog4cxx10
-sudo apt-get install -y libjemalloc-dev
-sudo apt-get install -y libsqlite3-dev
+distri=$(awk '/^DISTRIB_ID=|^ID=/' /etc/*-release | sed 's/.*=//' | sed 's/"//g' | tr '[:upper:]' '[:lower:]')
 
-echo 'Trying to install cmake'
-sudo apt-get install -y cmake
+case $distri in
+	"rhel") pkgman='yum';;
+	"debian") pkgman='apt';;
+	#more to come...
+esac
+
+if [ "x$pkgman" = "xyum" ]; then
+	echo "Building for Centos/Fedora/RHEL"
+	sudo yum install cmake
+	#sudo yum install boost boost-devel boost-thread
+	sudo yum install log4cxx log4cxx-devel
+	sudo yum install sqlite sqlite-devel
+	sudo yum install apr-util-devel
+	sudo yum install libmicrohttpd-devel
+	sudo yum install jemalloc
+else
+	if [ "x$pkgman" = "xapt" ]; then
+		echo 'The script will install packages using apt-get.' \
+		     'It can ask for your sudo password.'
+		     
+		echo 'Trying to install boost libraries'
+		sudo apt-get install -y libboost-dev libboost-system-dev libboost-thread-dev \
+		     libboost-filesystem-dev libboost-test-dev 
+		sudo apt-get install -y libboost-coroutine-dev \
+		     libboost-context-dev \
+		     libboost-program-options-dev libboost-regex-dev
+		     
+		echo 'Trying to install other libraries'
+		sudo apt-get install -y libapr1-dev libaprutil1-dev libaprutil1-dbd-sqlite3 libmicrohttpd-dev
+		sudo apt-get install -y liblog4cxx10-dev liblog4cxx10
+		sudo apt-get install -y libjemalloc-dev
+		sudo apt-get install -y libsqlite3-dev
+
+		echo 'Trying to install cmake'
+		sudo apt-get install -y cmake
+	else
+		echo "ERROR: Unknown package manager"
+		exit 1
+	fi
+fi #package manager check

--- a/prerequisites.sh
+++ b/prerequisites.sh
@@ -16,7 +16,9 @@ if [ "x$pkgman" = "xyum" ]; then
 	sudo yum install sqlite sqlite-devel
 	sudo yum install apr-util-devel
 	sudo yum install libmicrohttpd-devel
-	sudo yum install jemalloc
+	sudo yum install jemalloc-devel
+	sudo yum install python-devel
+	sudo yum install bzip2-devel
 else
 	if [ "x$pkgman" = "xapt" ]; then
 		echo 'The script will install packages using apt-get.' \

--- a/prerequisites.sh
+++ b/prerequisites.sh
@@ -2,9 +2,15 @@
 
 distri=$(awk '/^DISTRIB_ID=|^ID=/' /etc/*-release | sed 's/.*=//' | sed 's/"//g' | tr '[:upper:]' '[:lower:]')
 
+if [ "x$distri" = "x" ]; then
+	distri=$(find /etc/*-release | head -n1 | xargs grep -o '(\w*)' | sed 's/[()]//g' | tr '[:upper:]' '[:lower:]')
+fi
+
 case $distri in
 	"rhel") pkgman='yum';;
 	"debian") pkgman='apt';;
+	"santiago") pkgman='yum';; #RHEL6
+	"tikanga") pkgman='yum';; #RHEL5
 	#more to come...
 esac
 
@@ -40,7 +46,7 @@ else
 		echo 'Trying to install cmake'
 		sudo apt-get install -y cmake
 	else
-		echo "ERROR: Unknown package manager"
+		echo "ERROR: Unknown package manager: $distri"
 		exit 1
 	fi
 fi #package manager check

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -229,6 +229,7 @@ target_link_libraries(
     "${APRUTIL_LIBRARY}"
     "${APR_LIBRARY}"
     ${Boost_LIBRARIES}
+    pthread
 )
 
 add_test(mmap test_mmap)


### PR DESCRIPTION
I added support for yum based systems.
* RHEL7 has an outdated boost library, so we need to manually install 1.54 (not the current 1.60). cmake per default looks for libboost_*-mt.so, which aren't built on these plattforms, so I had to add the three lines:
```
set(Boost_USE_STATIC_LIBS OFF) 
set(Boost_USE_MULTITHREADED ON)  
set(Boost_USE_STATIC_RUNTIME OFF) 
```
* I had to manually add 'pthread' lib linking (in unittest/CMakeLists.txt)
* I'm not sure if this breaks anything on other platforms, as I live in a RHEL-only environment. So: before merging, do TEST.

* Some small typo fixed