### PR TITLE
Fix for boost.1.55 and later

### DIFF
--- a/akumulid/protocolparser.h
+++ b/akumulid/protocolparser.h
@@ -47,8 +47,8 @@ typedef typename Coroutine::caller_type Caller;
 
 namespace Akumuli {
 
-typedef typename boost::coroutines::asymmetric_coroutine<void()>::push_type Coroutine;
-typedef typename boost::coroutines::asymmetric_coroutine<void()>::pull_type Caller;
+typedef typename boost::coroutines::asymmetric_coroutine<void>::push_type Coroutine;
+typedef typename boost::coroutines::asymmetric_coroutine<void>::pull_type Caller;
 
 }
 

--- a/unittests/test_compression.cpp
+++ b/unittests/test_compression.cpp
@@ -45,7 +45,7 @@ void test_stream_chunked_op(TStreamWriter& writer, TStreamReader& reader, size_t
     TVal value = 100000;
 
     // Generate
-    for (int i = 0; i < (input_size-1); i++) {
+    for (size_t i = 0; i < (input_size-1); i++) {
         int delta = TVal(rand() % 1000 - 500);
         value += delta;
         input.push_back(value);


### PR DESCRIPTION
coroutine syntax is a bit different according to documentation)