### PR TITLE
Replace BOOST_MESSAGE with BOOST_TEST_MESSAGE

### DIFF
--- a/functests/storage_test.cpp
+++ b/functests/storage_test.cpp
@@ -1,6 +1,7 @@
 #include <iostream>
 #include <string>
 #include <set>
+#include <cmath>
 
 #include <sys/stat.h>
 #include <unistd.h>

--- a/unittests/test_blockstore.cpp
+++ b/unittests/test_blockstore.cpp
@@ -11,7 +11,7 @@
 #include "log_iface.h"
 
 void test_logger(aku_LogLevel tag, const char* msg) {
-    BOOST_MESSAGE(msg);
+    BOOST_TEST_MESSAGE(msg);
 }
 
 struct AkumuliInitializer {

--- a/unittests/test_column_store.cpp
+++ b/unittests/test_column_store.cpp
@@ -15,7 +15,7 @@
 
 void test_logger(aku_LogLevel tag, const char* msg) {
     AKU_UNUSED(tag);
-    BOOST_MESSAGE(msg);
+    BOOST_TEST_MESSAGE(msg);
 }
 
 struct AkumuliInitializer {

--- a/unittests/test_nbtree.cpp
+++ b/unittests/test_nbtree.cpp
@@ -16,7 +16,7 @@
 
 void test_logger(aku_LogLevel tag, const char* msg) {
     AKU_UNUSED(tag);
-    BOOST_MESSAGE(msg);
+    BOOST_TEST_MESSAGE(msg);
 }
 
 struct AkumuliInitializer {

--- a/unittests/test_queryprocessor.cpp
+++ b/unittests/test_queryprocessor.cpp
@@ -17,7 +17,7 @@ using namespace Akumuli::QP;
 
 void logger_stub(aku_LogLevel level, const char* msg) {
     if (level == AKU_LOG_ERROR) {
-        BOOST_MESSAGE(msg);
+        BOOST_TEST_MESSAGE(msg);
     }
 }
 

--- a/unittests/test_storage.cpp
+++ b/unittests/test_storage.cpp
@@ -24,7 +24,7 @@ using namespace QP;
 
 void test_logger(aku_LogLevel tag, const char* msg) {
     AKU_UNUSED(tag);
-    BOOST_MESSAGE(msg);
+    BOOST_TEST_MESSAGE(msg);
 }
 
 struct AkumuliInitializer {

--- a/unittests/test_util.cpp
+++ b/unittests/test_util.cpp
@@ -13,7 +13,7 @@
 using namespace Akumuli;
 
 void test_logger(aku_LogLevel tag, const char* msg) {
-    BOOST_MESSAGE(msg);
+    BOOST_TEST_MESSAGE(msg);
 }
 
 struct AkumuliInitializer {
@@ -140,7 +140,7 @@ BOOST_AUTO_TEST_CASE(test_crc32c_0) {
     auto crc32hw = chose_crc32c_implementation(CRC32C_hint::DETECT);
     auto crc32sw = chose_crc32c_implementation(CRC32C_hint::FORCE_SW);
     if (crc32hw == crc32sw) {
-        BOOST_MESSAGE("Can't compare crc32c implementation, hardware version is not available.");
+        BOOST_TEST_MESSAGE("Can't compare crc32c implementation, hardware version is not available.");
         return;
     }
     auto gen = []() {


### PR DESCRIPTION
I was unsuccessful compiling Akumuli on Ubuntu 16.10 Yakkety, because of `BOOST_MESSAGE` not being declared. As I understand it, `BOOST_MESSAGE` was deprecated since Boost 1.34 and has been permanently removed now (I have 1.61). 
`BOOST_TEST_MESSAGE` is the replacement.

In addition, I added the include statement for cmath, as I got another compilation error:
```
/opt/Akumuli/functests/storage_test.cpp:166:52: error: ‘NAN’ was not declared in this scope
                 result = { std::string(), paramid, NAN, sample_.paramid, sample_.timestamp };
                                                    ^~~
/opt/Akumuli/functests/storage_test.cpp:166:92: error: no match for ‘operator=’ (operand types are ‘Cursor::RowT’ and ‘<brace-enclosed initializer list>’)
                 result = { std::string(), paramid, NAN, sample_.paramid, sample_.timestamp };
                                                                                            ^
```