### PR TITLE
prerequisites.sh fix for centos

### DIFF
--- a/prerequisites.sh
+++ b/prerequisites.sh
@@ -8,6 +8,7 @@ fi
 
 case $distri in
 	"rhel") pkgman='yum';;
+    "centos") pkgman='yum';;
 	"debian") pkgman='apt';;
     "ubuntu") pkgman='apt';;
 	"santiago") pkgman='yum';; #RHEL6


### PR DESCRIPTION
I tried to install akumuli with official centos docker image (https://hub.docker.com/_/centos/) 
prerequisites wrote this:
ERROR: Unknown package manager: centos   