### PR TITLE
Do not hardcode install paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Release notes
 =============
 
+Version 0.7.30
+--------------
+
+IMPROVEMENTS
+
+* Use CMake macros for install directories from GNUInstallDirs.
+
 Version 0.7.29
 --------------
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 2.8)
 set(PACKAGE_VERSION "1ubuntu1.0")
 set(APP_VERSION_MAJOR "0")
 set(APP_VERSION_MINOR "7")
-set(APP_VERSION_PATCH "29")
+set(APP_VERSION_PATCH "30")
 
 set(APP_VERSION "${APP_VERSION_MAJOR}.${APP_VERSION_MINOR}.${APP_VERSION_PATCH}")
 add_definitions(-DAKU_VERSION="${APP_VERSION}")
@@ -60,6 +60,8 @@ add_definitions(-std=c++1y -fvisibility=hidden)
 # json parser from boost::property_tree needs this badly
 add_definitions(-DBOOST_SPIRIT_THREADSAFE)
 add_definitions(-DBOOST_PHOENIX_THREADSAFE)
+
+include(GNUInstallDirs)
 
 include_directories(./include)
 

--- a/akumulid/CMakeLists.txt
+++ b/akumulid/CMakeLists.txt
@@ -32,8 +32,7 @@ install(
     TARGETS
         akumulid
     RUNTIME DESTINATION
-        #${CMAKE_INSTALL_PREFIX}/bin
-        /usr/bin
+        ${CMAKE_INSTALL_BINDIR}
 )
 
 set(CPACK_GENERATOR "DEB")

--- a/libakumuli/CMakeLists.txt
+++ b/libakumuli/CMakeLists.txt
@@ -54,8 +54,7 @@ install(
     TARGETS
         akumuli
     LIBRARY DESTINATION
-        #${CMAKE_INSTALL_PREFIX}/lib
-        /usr/lib
+        ${CMAKE_INSTALL_LIBDIR}
 )
 
 install(
@@ -64,8 +63,7 @@ install(
 	  ../include/akumuli.h
 	  ../include/akumuli_def.h
     DESTINATION
-        #${CMAKE_INSTALL_PREFIX}/include
-        /usr/include
+        ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
 set(CPACK_GENERATOR "DEB")


### PR DESCRIPTION
Different distribution might have different paths for libraries and
binaries. For example, Fedora uses /usr/lib64 on x86_64 platform.