### PR TITLE
Add missing includes to storage2.cpp and eval.cpp

### DIFF
--- a/libakumuli/query_processing/eval.cpp
+++ b/libakumuli/query_processing/eval.cpp
@@ -4,6 +4,10 @@
 #include <functional>
 #include <set>
 
+#if defined(__APPLE__)
+#include <array>
+#endif
+
 #include <boost/algorithm/string.hpp>
 
 #include "muParser.h"

--- a/libakumuli/storage2.cpp
+++ b/libakumuli/storage2.cpp
@@ -41,6 +41,10 @@
 #include "fcntl_compat.h"
 #include <cstdlib>
 
+#if defined(__APPLE__)
+#include <stack>
+#endif
+
 namespace Akumuli {
 
 // Utility functions & classes //


### PR DESCRIPTION
This PR adds `#include <array>` to `eval.cpp` and `#include <stack>` to `storage2.cpp` for MacOS build.

See: https://github.com/akumuli/Akumuli/issues/382